### PR TITLE
SimpleCov and Spec folder name change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gem 'cane'
 gem 'reek'
 gem 'rake'
 gem 'rspec'
+gem 'simplecov', require: false, group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,50 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    cane (3.0.0)
+      parallel
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    kwalify (0.7.2)
+    parallel (1.22.1)
+    parser (3.1.2.0)
+      ast (~> 2.4.1)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    reek (6.1.1)
+      kwalify (~> 0.7.0)
+      parser (~> 3.1.0)
+      rainbow (>= 2.0, < 4.0)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+
+PLATFORMS
+  x86_64-darwin-21
+
+DEPENDENCIES
+  cane
+  rake
+  reek
+  rspec
+  simplecov
+
+BUNDLED WITH
+   2.3.13

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'simplecov'
+SimpleCov.start


### PR DESCRIPTION
Hey Team,

This PR includes the following changes:
- Renamed the 'test' folder to 'spec'
- Added SimpleCov gem to Gemfile.
- Added the spec_helper file to complete the instructions in the SimpleCov setup guide. We can get rid of this later if we wind up not needing it, but I think we'll be able to add more to this file in the future. 